### PR TITLE
Update kuchiki to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ license = "MIT"
 categories = ["html", "diff"]
 
 [dependencies]
-kuchiki = "0.5.1"
+kuchiki = "0.6"
 
 [[bin]]
 name = "html_diff"
+path = "src/main.rs"


### PR DESCRIPTION
Needed by rust-lang/rust#44884. 

See kuchiki-rs/kuchiki#38 for detail.